### PR TITLE
Adjusts masking, return rescaled output

### DIFF
--- a/src/transformers/models/patchtst/modeling_patchtst.py
+++ b/src/transformers/models/patchtst/modeling_patchtst.py
@@ -1660,6 +1660,7 @@ class PatchTSTForPrediction(PatchTSTPreTrainedModel):
         )
         # get output head
         y_hat = self.head(model_output.last_hidden_state)
+        y_hat_rescaled = y_hat * model_output.scale + model_output.loc
 
         loss_val = None
 
@@ -1675,19 +1676,18 @@ class PatchTSTForPrediction(PatchTSTPreTrainedModel):
                 # loss_val = nn.MSELoss(reduction='none')(distribution.mean, future_values)
                 # loss_val = weighted_average(loss_val)
             else:
-                y_hat = y_hat * model_output.scale + model_output.loc
                 loss = nn.MSELoss(reduction="mean")
-                loss_val = loss(y_hat, future_values)
+                loss_val = loss(y_hat_rescaled, future_values)
 
         loc = model_output.loc
         scale = model_output.scale
 
         if not return_dict:
-            outputs = (loss_val, y_hat, model_output.hidden_states, model_output.attentions, loc, scale)
+            outputs = (loss_val, y_hat_rescaled, model_output.hidden_states, model_output.attentions, loc, scale)
             return tuple(v for v in outputs if v is not None)
         return PatchTSTForPredictionOutput(
             loss=loss_val,
-            prediction_outputs=y_hat,
+            prediction_outputs=y_hat_rescaled,
             hidden_states=model_output.hidden_states,
             attentions=model_output.attentions,
             loc=loc,

--- a/src/transformers/models/patchtst/modeling_patchtst.py
+++ b/src/transformers/models/patchtst/modeling_patchtst.py
@@ -1396,6 +1396,11 @@ class PatchTSTForClassification(PatchTSTPreTrainedModel):
     def __init__(self, config: PatchTSTConfig):
         super().__init__(config)
 
+        # Turn off masking
+        if config.mask_input:
+            logger.debug("Setting `mask_input` parameter to False.")
+            config.mask_input = False
+
         self.model = PatchTSTModel(config)
         self.head = PatchTSTClassificationHead(config)
 
@@ -1589,6 +1594,12 @@ class PatchTSTForPrediction(PatchTSTPreTrainedModel):
 
     def __init__(self, config: PatchTSTConfig):
         super().__init__(config)
+
+        # Turn off masking
+        if config.mask_input:
+            logger.debug("Setting `mask_input` parameter to False.")
+            config.mask_input = False
+
         self.model = PatchTSTModel(config)
 
         if config.loss == "mse":
@@ -1788,7 +1799,11 @@ class PatchTSTForRegression(PatchTSTPreTrainedModel):
     # PatchTST model + Regression head
     def __init__(self, config: PatchTSTConfig):
         super().__init__(config)
-        self.model = PatchTSTModel(config)
+
+        # Turn off masking
+        if config.mask_input:
+            logger.debug("Setting `mask_input` parameter to False.")
+            config.mask_input = False
 
         self.model = PatchTSTModel(config)
         if config.loss == "mse":


### PR DESCRIPTION
# What does this PR do?

Sets `config.mask_input` to False in the `__init__` methods when using `PatchTSTforPrediction`, `PatchTSTforRegression`, `PatchTSTforClassification`.

Makes output more consistent in `PatchTSTforPrediction` by always returning the rescaled output, irrespective of the presence of `future_values`.
